### PR TITLE
5 score board shows roundid instead of roundnumber

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,4 +3,4 @@ from website import create_app
 app = create_app()
 
 if __name__ == '__main__':
-    app.run(debug=True)
+    app.run()

--- a/website/templates/matches.html
+++ b/website/templates/matches.html
@@ -55,6 +55,13 @@
                         <input type="submit" class="btn btn-sm btn-warning" value="Re-Open"
                             onclick="return confirm('Are you sure you want to re-open this match?')">
                     </form>
+                    <!-- A button which will open up the score-board.html page with this matches rounds loaded.-->
+                    <td>
+                    <form method="POST"
+                        action="{{ url_for('views.previous_rounds', match_id=match.id) }}">
+                        <input type="submit" class="btn btn-sm btn-success" value="Score Board">
+                    </form>
+                    </td>
                   {% endif %}
                 </td>
                 <td></td>

--- a/website/templates/score-board.html
+++ b/website/templates/score-board.html
@@ -17,7 +17,7 @@
             <th scope="col">Rounds</th>
             <th scope="col">Total</th>
             {% for round in rounds %}
-            <th scope="col">{{ round.id }}</th>
+            <th scope="col">{{ round.number }}</th>
             {% endfor %}
         </tr>
     </thead>

--- a/website/templates/score-keeper.html
+++ b/website/templates/score-keeper.html
@@ -69,14 +69,14 @@ action="{{ url_for('views.complete_match', match_id=match.id) }}">
             <tr>
                 <th scope="col">Rounds</th>
                 <th scope="col">Match Date </th>
-                <th scope="col">{{ players[match.player1] }} </th>
-                <th scope="col">{{ players[match.player2] }} </th>
+                <th scope="col">{{ players[match.player1] }} {{ player1_total }} </th>
+                <th scope="col">{{ players[match.player2] }} {{ player2_total }}</th>
             </tr>
         </thead>
         <tbody>
             {% for round in rounds %}
             <tr>
-                <td>{{ round.id }}</td>
+                <td>{{ round.number }}</td>
                 <td>{{ match.date.date() }}</td>
                 <td>{{ round.player1_score }}</td>
                 <td>{{ round.player2_score }}</td>

--- a/website/templates/seasons.html
+++ b/website/templates/seasons.html
@@ -27,6 +27,21 @@
                             onclick="return confirm('Are you sure you want to delete this season?')">
                     </form>
                 </td>
+                <!-- Button to open or close the season, depending on its current state-->
+                <td>
+                    {% if season.closed == False %}
+                    <form method="POST"
+                        action="{{ url_for('views.close_season', season_id=season.id) }}">
+                        <input type="submit" class="btn btn-sm btn-danger" value="Close Season"
+                            onclick="return confirm('Are you sure you want to close this season?')">
+                    </form>
+                    {% else %}
+                    <form method="POST"
+                        action="{{ url_for('views.open_season', season_id=season.id) }}">
+                        <input type="submit" class="btn btn-sm btn-success" value="Open Season"
+                            onclick="return confirm('Are you sure you want to open this season?')">
+                    </form>
+                    {% endif %}
             </tr>
             {% endfor %}
         </tbody>

--- a/website/views.py
+++ b/website/views.py
@@ -184,6 +184,25 @@ def delete_season(season_id):
     db.session.commit()
     return redirect(url_for('views.add_season'))
 
+#Route to close a season
+@views.post('/<int:season_id>/closeSeason/')
+def close_season(season_id):
+    season = Season.query.filter_by(id=season_id).first()
+    season.closed = True
+    db.session.commit()
+    return redirect(url_for('views.add_season'))
+
+#Route to open a season, only if there is no other open season
+@views.post('/<int:season_id>/openSeason/')
+def open_season(season_id):
+    season = Season.query.filter_by(id=season_id).first()
+    if Season.query.filter_by(closed=False).count() >0:
+        flash("Season already in progress", category="error")
+    else:
+        season.closed = False
+        db.session.commit()
+    return redirect(url_for('views.add_season'))
+
 #-------------------Matches-------------------
 
 @views.route("/matches", methods=["GET", "POST"])

--- a/website/views.py
+++ b/website/views.py
@@ -13,7 +13,7 @@ views = Blueprint("views", __name__)
 def home():
     return render_template("home.html")
 
-
+#------------------- Players -------------------
 # Players Page
 @views.route("/players", methods=["GET", "POST"])
 
@@ -80,6 +80,21 @@ def score_keeper():
         players = {player.id: player.first_name for player in Player.query.all()}
         player1_total = sum(round.player1_score for round in rounds)
         player2_total = sum(round.player2_score for round in rounds)
+        # Alert the user if either player scores at least 21 and there is no tie
+        if player1_total >= 21 and player1_total > player2_total:
+            flash (players[match.player1] + " Wins!", category="success")
+            
+            # Complete the match by making a request to the complete_match route
+            return redirect(url_for("views.complete_match", match_id=match.id))
+
+        elif player2_total >= 21 and player2_total > player1_total:
+            flash (players[match.player2] + " Wins!", category="success")
+
+            # Complete the match by making a request to the complete_match route
+            return redirect(url_for("views.complete_match", match_id=match.id))
+
+
+
         return render_template("score-keeper.html", players=players,match=match, rounds=rounds, player1_total=player1_total, player2_total=player2_total)
 
 
@@ -109,6 +124,9 @@ def score_board():
         player1_total = sum(round.player1_score for round in rounds)
         player2_total = sum(round.player2_score for round in rounds)
         return render_template("score-board.html", players=players,match=match, rounds=rounds, player1_total=player1_total, player2_total=player2_total)
+
+
+@views.post('/<int:match_id>/previousRounds/')
 def previous_rounds(match_id):
     match = Match.query.filter_by(id=match_id).first()
     rounds = Round.query.filter_by(match_id=match.id).all()
@@ -205,7 +223,7 @@ def delete_match(match_id):
     db.session.commit()
     return redirect(url_for('views.matches'))
 
-@views.post('/<int:match_id>/completeMatch/') 
+@views.route('/<int:match_id>/completeMatch/', methods=["GET", "POST"]) 
 def complete_match(match_id):
     match = Match.query.filter_by(id=match_id).first()
     rounds = Round.query.filter_by(match_id=match.id).all()


### PR DESCRIPTION
- Resolves #4 - Added ability to end the round automatically if either player scores above 21 and there is no tie
- Resolves #5 - Scoreboard now shows appropriate round numbers instead of round.id
- Resolves #6 - Added the ability to load the scoreboard with the rounds of any historical match
- Resolves #7 - Added the rolling score of each player in the score-keeper page
- Resolves #8 - Added the ability to open/close a season and check for a season that is already open
- Resolves #9 - Score keeper view now shows correct round numbers, not round.id